### PR TITLE
make restore command drop db before restoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "scripts": {
     "start": "node ./bin/www",
-    "restore": "node ./tools/restoretestdb.js",
+    "restore": "mongo --eval 'db.dropDatabase();';node ./tools/restoretestdb.js",
     "dump": "node ./tools/dumpdb.js"
   },
   "dependencies": {


### PR DESCRIPTION
tiny fix, without this it just adds new elements to the DB, cant remove them.